### PR TITLE
added support for time.Time fields

### DIFF
--- a/to_struct.go
+++ b/to_struct.go
@@ -3,6 +3,7 @@ package structmapper
 import (
 	"encoding/json"
 	"reflect"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -51,8 +52,22 @@ func StringMapToStruct(m map[string]string, s interface{}, strict bool) error {
 				continue
 			}
 			if value, exists := m[t]; exists {
+
+				// a := f.Type.Kind() == reflect.Struct
+				// b:= sv.Field(i).Interface()
+
+				_, isT := isTime(sv.Field(i))
+
 				if f.Type.Kind() == reflect.String {
 					m2[t] = value
+				} else if isT {
+					if value != "" {
+						tval, err := time.Parse(time.RFC3339, value)
+						if err != nil {
+							return errors.Wrap(err, "parsing time value")
+						}
+						m2[t] = tval
+					}
 				} else if f.Type.Kind() == reflect.Bool {
 					m2[t] = stringToBool(value)
 				} else if value != "" {


### PR DESCRIPTION
I'm doing some advanced tidying with the new invitations record type and part of that is using `time.Time` as a field type you can store/fetch. It already sort of worked using the json pathway but was a little ugly.